### PR TITLE
Add issue template for blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,0 +1,4 @@
+---
+name: Community issue
+about: Open a community issue
+---


### PR DESCRIPTION
This PR adds an issue template for opening a blank community issue. There's already a way to do this today in the GitHub UI, it's just fairly hidden and easy to miss

<img width="1552" alt="Screen Shot 2022-09-27 at 2 44 17 PM" src="https://user-images.githubusercontent.com/11656932/192620957-b5797cec-5a83-4b2c-b4fc-4cfd89188096.png">

cc @mrocklin @jacobtomlinson 

xref https://github.com/dask/community/issues/276